### PR TITLE
MDT-14: Implement upload new dataset confirmation modal

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,22 +1,87 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import UploadIcon from '@mui/icons-material/Upload';
 import DownloadIcon from '@mui/icons-material/Download';
 import MechanismCard from '../components/MechanismCard';
 import CaseCountCard from '../components/CaseCountCard';
 import FeatureCountCard from '../components/FeatureCountCard';
 
+function ConfirmationModal({ onClose, onProceed }: { onClose: () => void; onProceed: () => void }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Background overlay */}
+      <div className="absolute inset-0 bg-black/20" />
+      {/* Modal content */}
+      <div className="relative bg-white border-2 border-black rounded-lg shadow-2xl mx-4 p-4" style={{width: '489px', height: '152px'}}>
+        {/* Close X button */}
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 w-4 h-4 flex items-center justify-center text-black hover:text-gray-600 text-lg font-normal cursor-pointer"
+        >
+          ×
+        </button>
+        
+        {/* Content */}
+        <div className="pr-6 h-full flex flex-col justify-between">
+          <p className="text-black text-sm leading-normal mb-4">
+            Are you sure you want to upload a new dataset? The current analysis won't be saved. Consider downloading the report before uploading a new dataset.
+          </p>
+          
+          {/* Buttons */}
+          <div className="flex gap-3 justify-center">
+            <button
+              onClick={onProceed}
+              className="bg-gray-100 hover:bg-gray-200 text-gray-800 px-4 py-1.5 rounded text-sm font-medium transition-colors cursor-pointer"
+            >
+              Proceed to upload
+            </button>
+            <button
+              onClick={onClose}
+              className="bg-black hover:bg-gray-800 text-white px-6 py-1.5 rounded text-sm font-medium transition-colors cursor-pointer"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 const DashboardPage: React.FC = () => {
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const navigate = useNavigate();
+
+  const handleUploadNewDataset = () => {
+    setShowConfirmModal(true);
+  };
+
+  const handleProceedToUpload = () => {
+    setShowConfirmModal(false);
+    navigate('/');
+  };
+
+  const handleCloseModal = () => {
+    setShowConfirmModal(false);
+  };
+
   return (
     <div className="min-h-screen bg-white flex flex-col">
+      {showConfirmModal && (
+        <ConfirmationModal onClose={handleCloseModal} onProceed={handleProceedToUpload} />
+      )}
       {/* Top Bar */}
       <header className="w-full border-b flex items-center justify-between px-6 py-3 sticky top-0 bg-white z-10">
         <div className="text-sm font-medium">The Missing Data Tool</div>
         <div className="flex gap-6">
-          <button className="flex items-center gap-2 text-sm text-gray-700 hover:text-black font-medium">
+          <button 
+            className="flex items-center gap-2 text-sm text-gray-700 hover:text-black font-medium cursor-pointer"
+            onClick={handleUploadNewDataset}
+          >
             <UploadIcon fontSize="small" />
             Upload new dataset
           </button>
-          <button className="flex items-center gap-2 text-sm text-gray-700 hover:text-black font-medium">
+          <button className="flex items-center gap-2 text-sm text-gray-700 hover:text-black font-medium cursor-pointer">
             <DownloadIcon fontSize="small" />
             Download report
           </button>


### PR DESCRIPTION
- Add confirmation modal when clicking 'Upload new dataset' button
- Modal asks user to confirm before proceeding to upload page
- Implemented with exact design specifications (489x152px)
- Added proper cursor pointer interactions for all buttons
- Centered button layout within modal
- Navigation redirects to landing page on confirmation
- Black border, X close button, and responsive design